### PR TITLE
returning ids using group_concat

### DIFF
--- a/resources/sparql/process/participants.mustache
+++ b/resources/sparql/process/participants.mustache
@@ -4,7 +4,7 @@ PREFIX franzOption_clauseReorderer: <franz:identity>
 
 # Given a biological processes, return all participants in that process
 
-select ({{process-id}} as ?process_id) (group_concat(?ice; separator = ";") AS ?participant_ice_ids)
+select ({{process-id}} as ?process_id) (group_concat(?ice; separator = "{{separator}}") AS ?participant_ice_ids)
 {
   ?specificbp rdfs:subClassOf {{process-id}} .
   ?specificbp rdfs:subClassOf ?has_participant_r .

--- a/resources/sparql/process/participants.mustache
+++ b/resources/sparql/process/participants.mustache
@@ -1,0 +1,20 @@
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX iaouniprot: <http://kabob.ucdenver.edu/iao/uniprot/>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+
+# Given a biological processes, return all participants in that process
+
+select ({{process-id}} as ?process_id) (group_concat(?ice; separator = ";") AS ?participant_ice_ids)
+{
+  ?specificbp rdfs:subClassOf {{process-id}} .
+  ?specificbp rdfs:subClassOf ?has_participant_r .
+  ?has_participant_r owl:onProperty obo:RO_0000057 . # RO:has_participant
+  ?has_participant_r owl:someValuesFrom ?specificbioentity .
+  ?specificbioentity rdfs:subClassOf ?participant_bio_entity .
+  ?ice obo:IAO_0000219 ?participant_bio_entity .
+}
+group by ?participant_bio_entity
+
+# Local Variables:
+# mode: sparql
+# End:

--- a/resources/sparql/protein/binary-interaction-partners.mustache
+++ b/resources/sparql/protein/binary-interaction-partners.mustache
@@ -3,7 +3,7 @@ PREFIX franzOption_clauseReorderer: <franz:identity>
 
 # Return the proteins known to participate in binary interactions with the input protein identifier.
 
-select (<{{bio-id}}> as ?source_bio_id) (<{{ice-id}}> as ?ice_id) ("{{src-id}}" as ?ext_source_id) ?interaction_label ?partner_bio_id
+select  ("{{src-id}}" as ?ext_source_id) (<{{ice-id}}> as ?ice_id) ?interaction_label (group_concat(?partner_ice_id; separator = ";") AS ?partner_ice_ids)
 {
   ?specificbioentity rdfs:subClassOf <{{bio-id}}> .
 
@@ -24,7 +24,9 @@ select (<{{bio-id}}> as ?source_bio_id) (<{{ice-id}}> as ?ice_id) ("{{src-id}}" 
   ?has_participant_r2 owl:someValuesFrom ?interacting_partner .
   ?interacting_partner rdfs:subClassOf ?partner_bio_id .
   filter (?partner_bio_id != <{{bio-id}}>) .
+  ?partner_ice_id obo:IAO_0000219 ?partner_bio_id .
 }
+group by ?partner_bio_id ?interaction_label
 
 # Local Variables:
 # mode: sparql

--- a/resources/sparql/protein/binary-interaction-partners.mustache
+++ b/resources/sparql/protein/binary-interaction-partners.mustache
@@ -3,7 +3,7 @@ PREFIX franzOption_clauseReorderer: <franz:identity>
 
 # Return the proteins known to participate in binary interactions with the input protein identifier.
 
-select  ("{{src-id}}" as ?ext_source_id) (<{{ice-id}}> as ?ice_id) ?interaction_label (group_concat(?partner_ice_id; separator = ";") AS ?partner_ice_ids)
+select  ("{{src-id}}" as ?ext_source_id) (<{{ice-id}}> as ?ice_id) ?interaction_label (group_concat(?partner_ice_id; separator = "{{separator}}") AS ?partner_ice_ids)
 {
   ?specificbioentity rdfs:subClassOf <{{bio-id}}> .
 

--- a/src/kabob_query/api.clj
+++ b/src/kabob_query/api.clj
@@ -5,6 +5,13 @@
   defined in the `kabob-query.core` namespace."
   (:require [clojure.string :as s]))
 
+
+;; For queries that return lists of identifiers using the SPARQL group_concat
+;; function, the identifiers are delimited by the separator defined here.
+(def ^{:const true}
+  separator ";")
+
+
 (defmacro define-interface-fn
   [fn-name kb-sym fn-args & body]
   `(do

--- a/src/kabob_query/sparql/id.clj
+++ b/src/kabob_query/sparql/id.clj
@@ -6,7 +6,8 @@
             [mantle.collection :refer [single]]
             [mantle.io :refer [fmtstr]]
             [kabob-query.kb :refer [sparql-query]]
-            [kabob-query.template :refer [render]]))
+            [kabob-query.template :refer [render]])
+  (:import java.util.regex.Pattern))
 
 (defn ext-id->parts
   "Split into parts the external identifier that a user might specify to
@@ -50,7 +51,7 @@
   [ice-id]
   (let [[match nmspc ns_id] (re-matches #"http://kabob.ucdenver.edu/iao/([^/]+)/(.+)_ICE" ice-id)
         id (s/replace-first ns_id
-                            (java.util.regex.Pattern/compile (str (s/upper-case nmspc) "_"))
+                            (Pattern/compile (str (s/upper-case nmspc) "_"))
                             "")]
     (s/join ":" [nmspc id])))
 
@@ -74,24 +75,3 @@
   constructed; e.g. for \"UNIPROT_P12345_ICE\", return \"P12345\"."
   [id]
   (s/join "_" (butlast (rest (s/split (name id) #"_")))))
-
-(defmulti ice-id
-  "Return the primary (for some definition of 'primary') ICE identifier for a
-  BIO entity of a particular type, e.g. `:protein`, `:gene`, etc."
-  (fn [kb entity-type iao bio-id] entity-type))
-
-(defmulti ice-id1
-  "Since it is possible for a BIO entity to be denoted by multiple ICE
-  identifiers, we need some way to select one of these as *the* identifier to
-  which it should be mapped.  The method by which the primary identifier is
-  determined may vary by source (IAO)."
-  (fn [iao ids] iao))
-
-(defmethod ice-id1 :default ice-id1:default
-  [_ ids]
-  (last (sort (map ice-id->entity-id ids))))
-
-(defmethod ice-id :default ice-id:default
-  [kb _ iao bio-id]
-  (ice-id1 iao (filter #(= (str "iao" iao) (namespace %))
-                       (map #(single (vals %)) (query:ice kb bio-id)))))

--- a/src/kabob_query/sparql/id.clj
+++ b/src/kabob_query/sparql/id.clj
@@ -43,6 +43,18 @@
       (s/join [uri-ns (s/upper-case (s/join "_" [source id "ice"]))])
       (throw (ex-info (fmtstr "'~a' is not a valid IAO source identifier." source) (or ns-map {}))))))
 
+(defn ice-uri->id
+  "Translate an ICE URI into a source-specific identifier. Source-specific IDs
+  are expected to be of the form `<source>:<id>`, for example:
+  `uniprot:p15692`."
+  [ice-id]
+  (let [[match nmspc ns_id] (re-matches #"http://kabob.ucdenver.edu/iao/([^/]+)/(.+)_ICE" ice-id)
+        id (s/replace-first ns_id
+                            (java.util.regex.Pattern/compile (str (s/upper-case nmspc) "_"))
+                            "")]
+    (s/join ":" [nmspc id])))
+
+
 (defn query:bioentity
   [kb ice-id]
   (sparql-query kb (render "sparql/id/bioentity" {:ice-id ice-id})))

--- a/src/kabob_query/sparql/process.clj
+++ b/src/kabob_query/sparql/process.clj
@@ -1,0 +1,21 @@
+(ns kabob-query.sparql.process
+  (:require [clojure.string :as s]
+            [clojure.pprint :refer [pprint]]
+            [mantle.collection :refer [single]]
+            [kabob-query.api :refer [define-interface-fn]]
+            [kabob-query.kb :refer [sparql-query]]
+            [kabob-query.sparql.id :as id :refer [ice-id1]]
+            [kabob-query.template :refer [render]]))
+
+(define-interface-fn participants kb
+  [process-id]
+  ;; the query uses group_concat to return a semi-colon-delimited list of
+  ;; ICE URIs for the interaction partners.
+  (let [bio->ext (fn [id_list]
+                   (let [ids (s/split id_list #";")
+                         short_ids (sort (map id/ice-uri->id ids))]
+                     (s/join ";" short_ids )))]
+    (map #(assoc % '?/ext_participant_ids (bio->ext (get % '?/participant_ice_ids)))
+         (sparql-query kb
+                       (render "sparql/process/participants"
+                               {:process-id process-id})))))

--- a/src/kabob_query/sparql/process.clj
+++ b/src/kabob_query/sparql/process.clj
@@ -1,10 +1,8 @@
 (ns kabob-query.sparql.process
   (:require [clojure.string :as s]
-            [clojure.pprint :refer [pprint]]
-            [mantle.collection :refer [single]]
-            [kabob-query.api :refer [define-interface-fn]]
+            [kabob-query.api :as api :refer [define-interface-fn]]
             [kabob-query.kb :refer [sparql-query]]
-            [kabob-query.sparql.id :as id :refer [ice-id1]]
+            [kabob-query.sparql.id :as id]
             [kabob-query.template :refer [render]]))
 
 (define-interface-fn participants kb
@@ -14,8 +12,9 @@
   (let [bio->ext (fn [id_list]
                    (let [ids (s/split id_list #";")
                          short_ids (sort (map id/ice-uri->id ids))]
-                     (s/join ";" short_ids )))]
+                     (s/join api/separator short_ids )))]
     (map #(assoc % '?/ext_participant_ids (bio->ext (get % '?/participant_ice_ids)))
          (sparql-query kb
                        (render "sparql/process/participants"
-                               {:process-id process-id})))))
+                               {:process-id process-id
+                                :separator api/separator})))))

--- a/src/kabob_query/sparql/protein.clj
+++ b/src/kabob_query/sparql/protein.clj
@@ -7,16 +7,6 @@
             [kabob-query.sparql.id :as id :refer [ice-id1]]
             [kabob-query.template :refer [render]]))
 
-;; ------------------------------------------------------------- utility --- ;;
-
-(defmethod ^{:private true} ice-id1 "uniprot" ice-id1:uniprot
-  [iao ids]
-  (let [entry-ids (sort (map id/ice-id->entity-id ids))]
-    (or (last (reduce #(if (.startsWith %2 "P") (conj %1 %2) %1) [] entry-ids))
-        (last entry-ids))))
-
-;; ----------------------------------------------------------------- API --- ;;
-
 (define-interface-fn cellular-components kb
   [source-id]
   (let [ice-id (id/id->ice-uri source-id (:iao-namespaces kb))]
@@ -39,20 +29,13 @@
   [source-id]
   (let [ice-uri (id/id->ice-uri source-id (:iao-namespaces kb))
         [iao eid] (id/ext-id->parts source-id)
-        bio->ext (fn [id]
-                   (let [fqbn (id/fq kb id)
-                         enid (id/ice-id kb :protein iao fqbn)]
-                     (id/parts->ext-id iao enid)))]
-    ;; We enrich the resultset that is returned with our best guess at the
-    ;; 'primary' external ID for the partner proteins.  Unfortunately, this is
-    ;; quite and expensive operation, since it requires us to go back to the
-    ;; store to retrieve all of the source-specific IDs that may denote the BIO
-    ;; entity.
-    ;;
-    ;; Ideally, we'd want to group by the `partner_bio_id` and use something
-    ;; like MySQL's `group_concat` to collapse the all of the records for each
-    ;; partner ID into a single row.
-    (map #(assoc % '?/ext_partner_id (bio->ext (get % '?/partner_bio_id)))
+        ;; the query uses group_concat to return a semi-colon-delimited list of
+        ;; ICE URIs for the interaction partners.
+        bio->ext (fn [id_list]
+                   (let [ids (s/split id_list #";")
+                         short_ids (sort (map id/ice-uri->id ids))]
+                     (s/join ";" short_ids )))]
+    (map #(assoc % '?/ext_partner_ids (bio->ext (get % '?/partner_ice_ids)))
          (sparql-query kb
                        (render "sparql/protein/binary-interaction-partners"
                                {:src-id source-id

--- a/src/kabob_query/sparql/protein.clj
+++ b/src/kabob_query/sparql/protein.clj
@@ -1,10 +1,9 @@
 
 (ns kabob-query.sparql.protein
   (:require [clojure.string :as s]
-            [mantle.collection :refer [single]]
-            [kabob-query.api :refer [define-interface-fn]]
+            [kabob-query.api :as api :refer [define-interface-fn]]
             [kabob-query.kb :refer [sparql-query]]
-            [kabob-query.sparql.id :as id :refer [ice-id1]]
+            [kabob-query.sparql.id :as id]
             [kabob-query.template :refer [render]]))
 
 (define-interface-fn cellular-components kb
@@ -34,10 +33,11 @@
         bio->ext (fn [id_list]
                    (let [ids (s/split id_list #";")
                          short_ids (sort (map id/ice-uri->id ids))]
-                     (s/join ";" short_ids )))]
+                     (s/join api/separator short_ids )))]
     (map #(assoc % '?/ext_partner_ids (bio->ext (get % '?/partner_ice_ids)))
          (sparql-query kb
                        (render "sparql/protein/binary-interaction-partners"
                                {:src-id source-id
                                 :ice-id ice-uri
-                                :bio-id (id/bio-id kb ice-uri)})))))
+                                :bio-id (id/bio-id kb ice-uri)
+                                :separator api/separator})))))

--- a/test/kabob_query/sparql/id_test.clj
+++ b/test/kabob_query/sparql/id_test.clj
@@ -13,6 +13,11 @@
   (fact (id/ice-id->entity-id "FOO_P123_ICE") => "P123")
   (fact (id/ice-id->entity-id "FOO_P_123_ICE") => "P_123"))
 
+
+(facts
+  (fact (id/ice-uri->id "http://kabob.ucdenver.edu/iao/uniprot/UNIPROT_A0A0G2KB10_ICE") => "uniprot:A0A0G2KB10")
+  (fact (id/ice-uri->id "http://kabob.ucdenver.edu/iao/refseq/REFSEQ_XP_005158717_ICE") => "refseq:XP_005158717"))
+
 (facts "The 'highest' lexographically sorted ID is used as the primary ID."
   (fact "default"
     (#'id/ice-id1 "iao-w/out-method" ["SRC_03_ICE" "SRC_09_ICE" "SRC_01_ICE"])

--- a/test/kabob_query/sparql/id_test.clj
+++ b/test/kabob_query/sparql/id_test.clj
@@ -17,8 +17,3 @@
 (facts
   (fact (id/ice-uri->id "http://kabob.ucdenver.edu/iao/uniprot/UNIPROT_A0A0G2KB10_ICE") => "uniprot:A0A0G2KB10")
   (fact (id/ice-uri->id "http://kabob.ucdenver.edu/iao/refseq/REFSEQ_XP_005158717_ICE") => "refseq:XP_005158717"))
-
-(facts "The 'highest' lexographically sorted ID is used as the primary ID."
-  (fact "default"
-    (#'id/ice-id1 "iao-w/out-method" ["SRC_03_ICE" "SRC_09_ICE" "SRC_01_ICE"])
-    => "09"))


### PR DESCRIPTION
This pull request demonstrates returning external IDs in the same format as provided by the user for input using the SPARQL group_concat function.